### PR TITLE
Supports

### DIFF
--- a/NVCenter/README.md
+++ b/NVCenter/README.md
@@ -107,9 +107,13 @@ noisycircscheduled = InsertCircuitNoise[List /@ circuit, NVCenterDelft[], Replac
 noisycirc = Extractcircuit @ noisycircscheduled;
 ApplyCircuit[rho, noisycirc]
 ```
-Variable ``noisycircscheduled`` contains noise-decorated ``circuit`` together with its schedule.
+First, variable ``noisycircscheduled`` contains noise-decorated ``circuit`` together with its schedule.
 Command ``List /@ circuit`` imposes serial implementation, 
 turning every element into a set, i.e., maps a set {a,b,c,...} to {{a},{b},{c}...}. 
-Therefore, passive noise becomes more prevalent; however, given that dynamical decoupling is assumed, the coherence values (T1 and T2) supposed to be high with this implementation. Note that, option ``ReplaceAliases`` replaces gate aliases/custom gates into standard **QuESTlink** operations. For instance ``Init`` gate, which is intialisation is defined as amplitude damping operation.  
+Therefore, passive noise becomes more prevalent; however, given that dynamical decoupling is assumed, 
+the coherence values (T1 and T2) supposed to be high with this implementation.
+Note that, option ``ReplaceAliases`` replaces gate aliases/custom gates into standard **QuESTlink** operations.
+For instance ``Init`` gate, which is intialisation is defined as amplitude damping operation.
 Variable ``noisycirc`` contains noise-decorated ``circuit`` that is ready for simulation. 
-Command ``ExtractCircuit[]`` basically removes the schedule information.
+Second, the command ``ExtractCircuit[]`` basically removes the schedule information.
+Finally, command ``ApplyCircuit`` operates ``noisycirc`` to a density of state ``rho``. 

--- a/NVCenter/README.md
+++ b/NVCenter/README.md
@@ -112,8 +112,8 @@ Command ``Serialize @ circuit`` imposes serial implementation,
 turning every element into a set, i.e., maps a set {a,b,c,...} to {{a},{b},{c}...}. 
 Therefore, passive noise becomes more prevalent; however, given that dynamical decoupling is assumed, 
 the coherence values (T1 and T2) supposed to be high with this implementation.
-Note that, option ``ReplaceAliases`` replaces gate aliases/custom gates into standard **QuESTlink** operations.
-For instance ``Init`` gate, which is intialisation is defined as amplitude damping operation.
+Note that, option ``ReplaceAliases`` replaces gate aliases/custom gates into standard **QuESTlink** operations:
+for instance ``Init`` gate here is defined as an amplitude damping.
 Variable ``noisycirc`` contains noise-decorated ``circuit`` that is ready for simulation. 
 Second, the command ``ExtractCircuit[]`` basically removes the schedule information.
 Finally, command ``ApplyCircuit`` operates ``noisycirc`` upon the density matrix ``rho``. 

--- a/NVCenter/README.md
+++ b/NVCenter/README.md
@@ -116,4 +116,4 @@ Note that, option ``ReplaceAliases`` replaces gate aliases/custom gates into sta
 For instance ``Init`` gate, which is intialisation is defined as amplitude damping operation.
 Variable ``noisycirc`` contains noise-decorated ``circuit`` that is ready for simulation. 
 Second, the command ``ExtractCircuit[]`` basically removes the schedule information.
-Finally, command ``ApplyCircuit`` operates ``noisycirc`` to a density of state ``rho``. 
+Finally, command ``ApplyCircuit`` operates ``noisycirc`` upon the density matrix ``rho``. 

--- a/NVCenter/README.md
+++ b/NVCenter/README.md
@@ -9,11 +9,11 @@ There is currently one virtual NV-center device, namely NV-center diamond that i
 **Table of contents**
 1. [Characteristics](#characteristics)
 2. [Native operations](#native-operations)
-3. [Parameters](#parameters)
+3. [Parameters and usage](#parameters-and-usage)
 
 ## Characteristics
 
-NV-center has star-shaped connectivity, where the NV<sup>-</sup>  electron spin is sitting in the center, surrounded by the nuclear spins C<sup>13</sup> &mdash; and may also involve N<sup>14</sup> spin.
+NV-center has star-shaped connectivity, where the NV<sup>-</sup>  electron spin is sitting in the center, surrounded by the nuclear spins <sup>13</sup>C &mdash; and may also involve <sup>14</sup>Nq spin.
 We set the electron spin to be indexed 0 in the program. See the picture below, where q0 is the electron spin and the rest are nuclear spin. The green circle represents nitrogen spin if you want to use it; this is decided in the setting up the parameters, e.g.,  particular fidelities and coherence time.
 
 
@@ -40,7 +40,7 @@ where  $$\mathtt{CR\sigma[\theta]}=\|0\rangle\langle0\|\otimes R\sigma(\theta)+\
 - Doing nothing; remember it will introduce passive noise
 $$\mathtt{Wait_q[\Delta t]}$$
 
-## Parameters
+## Parameters and usage
 
 The following configuration takes inspiration from devices at the University of Delft: a virtual NV-center contains six qubits without considering the nitrogen spin. 
 
@@ -100,4 +100,16 @@ Options[NVCenterDelft] = {
    };
 ```
 
+In practice, dynamical decoupling is constantly applied to passive qubits to mitigate unwanted interaction. For instance, let ``circuit`` be a circuit comprises native operations. The following command obtain noisy version of running ``circuit`` on the virtual NV-center defined above.
 
+```Mathematica
+noisycircscheduled = InsertCircuitNoise[List /@ circuit, NVCenterDelft[], ReplaceAliases -> True];
+noisycirc = Extractcircuit @ noisycircscheduled;
+ApplyCircuit[rho, noisycirc]
+```
+Variable ``noisycircscheduled`` contains noise-decorated ``circuit`` together with its schedule.
+Command ``List /@ circuit`` imposes serial implementation, 
+turning every element into a set, i.e., maps a set {a,b,c,...} to {{a},{b},{c}...}. 
+Therefore, passive noise becomes more prevalent; however, given that dynamical decoupling is assumed, the coherence values (T1 and T2) supposed to be high with this implementation. Note that, option ``ReplaceAliases`` replaces gate aliases/custom gates into standard **QuESTlink** operations. For instance ``Init`` gate, which is intialisation is defined as amplitude damping operation.  
+Variable ``noisycirc`` contains noise-decorated ``circuit`` that is ready for simulation. 
+Command ``ExtractCircuit[]`` basically removes the schedule information.

--- a/NVCenter/README.md
+++ b/NVCenter/README.md
@@ -103,12 +103,12 @@ Options[NVCenterDelft] = {
 In practice, dynamical decoupling is constantly applied to passive qubits to mitigate unwanted interaction. For instance, let ``circuit`` be a circuit comprises native operations. The following command obtain noisy version of running ``circuit`` on the virtual NV-center defined above.
 
 ```Mathematica
-noisycircscheduled = InsertCircuitNoise[List /@ circuit, NVCenterDelft[], ReplaceAliases -> True];
+noisycircscheduled = InsertCircuitNoise[Serialize @ circuit, NVCenterDelft[], ReplaceAliases -> True];
 noisycirc = Extractcircuit @ noisycircscheduled;
 ApplyCircuit[rho, noisycirc]
 ```
 First, variable ``noisycircscheduled`` contains noise-decorated ``circuit`` together with its schedule.
-Command ``List /@ circuit`` imposes serial implementation, 
+Command ``Serialize @ circuit`` imposes serial implementation, 
 turning every element into a set, i.e., maps a set {a,b,c,...} to {{a},{b},{c}...}. 
 Therefore, passive noise becomes more prevalent; however, given that dynamical decoupling is assumed, 
 the coherence values (T1 and T2) supposed to be high with this implementation.

--- a/SemiconductorSpin/README.md
+++ b/SemiconductorSpin/README.md
@@ -9,7 +9,7 @@ There is currently one virtual spin qubit in semiconductor quantum dots device, 
 **Table of contents**
 1. [Characteristics](#characteristics)
 2. [Native operations](#native-operations)
-3. [Parameters](#parameters)
+3. [Parameters and usage](#parameters-and-usage)
 
 
 ## Characteristics
@@ -47,7 +47,7 @@ $$\mathtt{C_p[X_q]}$$
 - Doing nothing; remember it will introduce passive noise
 $$\mathtt{Wait_q[\Delta t]}$$
 
-## Parameters
+## Parameters and usage
 
 The following configuration takes inspiration from a device at the University of Delft: six-qubit silicon device based on this [reference](https://doi.org/10.1038/s41586-022-05117-x). Device architecture is pictured above (see **Characteristics**).
 
@@ -123,7 +123,7 @@ e.g., virtual device with configuration above.
 
 ```Mathematica
 noisycircscheduled = InsertCircuitNoise[Serialize @ circuit, SiliconDelft[], ReplaceAliases -> True];
-noisycirc = Extractcircuit @ noisycircscheduled;
+noisycirc = ExtractCircuit @ noisycircscheduled;
 ApplyCircuit[rho, noisycirc];
 ```
 First, variable ``noisycircscheduled`` contains noise-decorated circuit together with its schedule.
@@ -132,8 +132,8 @@ turning every element into a set, i.e., maps a set {a,b,c,...} to {{a},{b},{c}..
 Therefore, passive noise becomes more prevalent; however, given that dynamical decoupling
 is assumed, the coherence values (T1 and T2) supposed to be high with this implementation.
 Note that, option ``ReplaceAliases`` replaces gate aliases/custom gates into standard 
-**QuESTlink** operations. For instance ``Init`` gate,
-which is intialisation is defined as a series of operations involving parity measurements.
+**QuESTlink** operations: for instance ``Init`` gate here will be replaced with a
+series of operations involving parity measurements.
 Variable ``noisycirc`` contains noise-decorated ``circuit`` that is ready for simulation.
 Second, the command ``ExtractCircuit[]`` basically removes the schedule information.
 Finally, command ``ApplyCircuit`` operates ``noisycirc`` upon the density matrix ``rho``.

--- a/SemiconductorSpin/README.md
+++ b/SemiconductorSpin/README.md
@@ -116,4 +116,25 @@ Options[SiliconDelft] =
    };
 ```
 
+It is common to apply gates in serial manner in practice, which adds an asumption that
+some dynamical decoupling sequences are constantly applied to passive qubits.
+The following command obtain the noisy version of ``circuit`` running on a virtual silicon spin qubit, 
+e.g., virtual device with configuration above.
+
+```Mathematica
+noisycircscheduled = InsertCircuitNoise[Serialize @ circuit, SiliconDelft[], ReplaceAliases -> True];
+noisycirc = Extractcircuit @ noisycircscheduled;
+ApplyCircuit[rho, noisycirc];
+```
+First, variable ``noisycircscheduled`` contains noise-decorated circuit together with its schedule.
+Command ``Serialize @ circuit`` imposes simple serial implementation,
+turning every element into a set, i.e., maps a set {a,b,c,...} to {{a},{b},{c}...}.
+Therefore, passive noise becomes more prevalent; however, given that dynamical decoupling
+is assumed, the coherence values (T1 and T2) supposed to be high with this implementation.
+Note that, option ``ReplaceAliases`` replaces gate aliases/custom gates into standard 
+**QuESTlink** operations. For instance ``Init`` gate,
+which is intialisation is defined as a series of operations involving parity measurements.
+Variable ``noisycirc`` contains noise-decorated ``circuit`` that is ready for simulation.
+Second, the command ``ExtractCircuit[]`` basically removes the schedule information.
+Finally, command ``ApplyCircuit`` operates ``noisycirc`` upon the density matrix ``rho``.
 

--- a/SuperconductingQubit/README.md
+++ b/SuperconductingQubit/README.md
@@ -9,7 +9,7 @@ There is currently one virtual superconducting qubit devices, which is supercond
 **Table of contents**
 1. [Characteristics](#characteristics)
 2. [Native operations](#native-operations)
-3. [Parameters](#parameters)
+3. [Parameters and usage](#parameters-and-usage)
 
 ## Characteristics
 
@@ -101,3 +101,25 @@ Options[SuperconductingHub] = {
    ZZPassiveNoise -> True
    };
 ```
+
+Superconducting qubits devices typically allow full parallelism in practice.
+Full parallel configuration is default implementation in **QuESTlink**. Therefore,
+implementing a circuit in this virtual device is simpler than other virtual devices.
+See the following example of usage, where we want to emulate running ``circuit`` that
+comprises legitimate operations on to a virtual superconducting qubits, e.g., a device
+with configuration given above.
+
+```Mathematica
+noisycircscheduled = InsertCircuitNoise[circuit, SuperconductingHub[], ReplaceAliases -> True];
+noisycirc = ExtractCircuit @ noisycircscheduled;
+ApplyCircuit[rho, noisycirc];
+```
+First, variable ``noisycircscheduled`` contains noise-decorated circuit together with its schedule.
+Passing ``circuit`` directly will arrange gates implementation in full parallell; one can 
+see this in the schedule, use ``DrawCircuit[noisycircscheduled]``.
+Note that, option ``ReplaceAliases`` replaces gate aliases/custom gates into standard 
+**QuESTlink** operations: for instance ``Init`` gate here replaces the state into the corresponding thermal state.
+Variable ``noisycirc`` contains noise-decorated ``circuit`` that is ready for simulation.
+Second, the command ``ExtractCircuit[]`` basically removes the schedule information.
+Finally, command ``ApplyCircuit`` operates ``noisycirc`` upon the density matrix ``rho``.
+

--- a/TrappedIon/README.md
+++ b/TrappedIon/README.md
@@ -144,12 +144,12 @@ The simulation of the multi-node ion trap is performed on the total density matr
 Therefore, we partition the density matrix into the corresponding nodes. 
 The option ``MapQubits -> True`` will map the local indices within a node into
 the global indices for the whole density matrix. This is useful to check the circuit
-arrangement globally, for instance command
+arrangement globally, for instance, command
 ```Mathematica 
 DrawCircuit @ CircTrappedIons[circuit, TrappedIonOxford[], MapQubits -> True]
 ```
 will draw the (noiseless) circuits arranged according to multi-nodes indices. 
-However, to obtain the noise-decorated ``circuit`` to simulate on the noisy
+However, to obtain the noise-decorated ``circuit``, to simulate it on the noisy
 ion traps, one must set ``MapQubits -> False``. See example below.
 ```Mathematica
 mytraps = TrappedIonOxford[]; 
@@ -159,7 +159,9 @@ ApplyCircuit[rho, noisycirc]
 ```
 First, variable ``noisycircscheduled`` contains noise-decorated ``circuit`` together with its schedule.
 Command ``CircTrappedIons[circuit, mytraps, MapQubits -> False]`` imposes serial implementation
-locally to the node, but parrallel with respect to different nodes.
+locally to the node, but parallel with respect to different nodes.
+Remark that command ``InsertCircuitNoise[]`` will update the state of the virtual device instance, namely,
+``mytraps`` in this case; for example, the arrangement of the ions is updated.
 Note that, option ``ReplaceAliases`` replaces gate aliases/custom gates into standard **QuESTlink** operations:
 for instance ``Init`` gate here is defined as amplitude damping.
 Variable ``noisycirc`` contains noise-decorated ``circuit`` that is ready for simulation. 

--- a/vqd.wl
+++ b/vqd.wl
@@ -670,10 +670,12 @@ Begin["`Private`"];
 		zzpassivenoise=OptionValue @ ZZPassiveNoise
 		},
 		
-		(* some assertions to check the inputted parameters *)
-		Catch @ If[CountDistinct[Values@qubitfreq]==Length@qubitfreq, 
+		(* some assertions to check the inputted parameters. 
+		TODO: distinct when coupled 
+		*)
+		(*Catch @ If[CountDistinct[Values@qubitfreq]==Length@qubitfreq, 
 			Throw @ Message[QubitFreq::error, "Every qubit frequency value given in QubitFreq must be distinct."]
-		];
+		];*)
 		
 		Module[{ccv, ug, stdpn, zzInteraction, zzPN, lessNeighbor, zzon, passivenoise, deltaT, activeq, counter=0, init=True}
 			,		


### PR DESCRIPTION
A bug in SQC assertion. Distinct qubit freq is unnecessary. We need the distinct coupled qubits only. 